### PR TITLE
make type constructors public

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -1,7 +1,7 @@
-use serde::{Serialize, Deserialize};
-use schemars::JsonSchema;
-use std::convert::TryFrom;
 use cardano_serialization_lib as csl;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use std::convert::TryFrom;
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]
@@ -30,11 +30,15 @@ pub struct TxOutput {
 
 impl TxOutput {
     pub fn find_ada_asset(&self) -> Option<&Asset> {
-        self.amount.iter().find(|asset| asset.unit == "lovelace" || asset.unit == "")
+        self.amount
+            .iter()
+            .find(|asset| asset.unit == "lovelace" || asset.unit == "")
     }
 
     pub fn has_non_ada_assets(&self) -> bool {
-        self.amount.iter().any(|asset| asset.unit != "lovelace" && asset.unit != "")
+        self.amount
+            .iter()
+            .any(|asset| asset.unit != "lovelace" && asset.unit != "")
     }
 }
 
@@ -45,44 +49,39 @@ pub struct UTxO {
     pub output: TxOutput,
 }
 
-
 #[derive(Serialize, Deserialize, Debug, Clone, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct CostModels {
-    pub(crate) plutus_v1: Option<Vec<i64>>,
-    pub(crate) plutus_v2:  Option<Vec<i64>>,
-    pub(crate) plutus_v3: Option<Vec<i64>>,
+    pub plutus_v1: Option<Vec<i64>>,
+    pub plutus_v2: Option<Vec<i64>>,
+    pub plutus_v3: Option<Vec<i64>>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct ExUnitPrices {
-    pub(crate) mem_price: SubCoin,
-    pub(crate) step_price: SubCoin,
+    pub mem_price: SubCoin,
+    pub step_price: SubCoin,
 }
 
 impl ExUnitPrices {
     pub fn to_csl(&self) -> csl::ExUnitPrices {
-        csl::ExUnitPrices::new(
-            &self.mem_price.to_csl(),
-            &self.step_price.to_csl()
-        )
+        csl::ExUnitPrices::new(&self.mem_price.to_csl(), &self.step_price.to_csl())
     }
 }
-
 
 #[derive(Serialize, Deserialize, Debug, Clone, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct SubCoin {
-    pub(crate) numerator: u64,
-    pub(crate) denominator: u64,
+    pub numerator: u64,
+    pub denominator: u64,
 }
 
 impl SubCoin {
     pub fn to_csl(&self) -> csl::UnitInterval {
         csl::UnitInterval::new(
             &csl::BigNum::from(self.numerator),
-            &csl::BigNum::from(self.denominator)
+            &csl::BigNum::from(self.denominator),
         )
     }
 }
@@ -90,6 +89,6 @@ impl SubCoin {
 #[derive(Serialize, Deserialize, Debug, Clone, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct ExUnits {
-    pub(crate) mem: u64,
-    pub(crate) steps: u64,
+    pub mem: u64,
+    pub steps: u64,
 }


### PR DESCRIPTION
some of the types have private members, which makes them hard to construct from outside of the crate. Made them public so that they can be constructed outside of the crate.