### PR TITLE
Expose script context bytes in EvalRedeemerResult

### DIFF
--- a/schemas/ValidationResult.schema.json
+++ b/schemas/ValidationResult.schema.json
@@ -25,6 +25,12 @@
         "provided_ex_units": {
           "$ref": "#/$defs/ExUnits"
         },
+        "script_context_bytes": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "success": {
           "type": "boolean"
         },

--- a/src/validators/phase_2/eval_redeemer.rs
+++ b/src/validators/phase_2/eval_redeemer.rs
@@ -65,6 +65,11 @@ pub fn eval_redeemer(
             .into_script_context(redeemer, datum.as_ref())
             .expect("couldn't create script context from transaction?");
 
+        let script_context_data = script_context.to_plutus_data();
+        let script_context_bytes = uplc::plutus_data_to_bytes(&script_context_data)
+            .ok()
+            .map(hex::encode);
+
         let program = match script_context {
             ScriptContext::V1V2 { .. } => if let Some(datum) = datum {
                 program.apply_data(datum)
@@ -72,9 +77,9 @@ pub fn eval_redeemer(
                 program
             }
             .apply_data(redeemer.data.clone())
-            .apply_data(script_context.to_plutus_data()),
+            .apply_data(script_context_data),
 
-            ScriptContext::V3 { .. } => program.apply_data(script_context.to_plutus_data()),
+            ScriptContext::V3 { .. } => program.apply_data(script_context_data),
         };
 
         let eval_result = if let Some(costs) = cost_mdl_opt {
@@ -107,6 +112,7 @@ pub fn eval_redeemer(
             success: error.as_ref().is_none(),
             error: error.as_ref().map(|e| e.to_string()),
             logs: logs,
+            script_context_bytes,
         };
 
         (new_redeemer, error)
@@ -213,6 +219,7 @@ fn eval_redeemer_result(
         success: false,
         error: Some(error.to_string()),
         logs: vec![],
+        script_context_bytes: None,
     };
     (new_redeemer, Some(error))
 }

--- a/src/validators/validation_result.rs
+++ b/src/validators/validation_result.rs
@@ -28,6 +28,7 @@ pub struct EvalRedeemerResult {
     pub logs: Vec<String>,
     pub success: bool,
     pub error: Option<String>,
+    pub script_context_bytes: Option<String>,
 }
 
 #[derive(Serialize, Deserialize, JsonSchema, Clone, Debug)]

--- a/types/cquisitor_lib.d.ts
+++ b/types/cquisitor_lib.d.ts
@@ -1937,6 +1937,7 @@ export interface EvalRedeemerResult {
   index: bigint;
   logs: string[];
   provided_ex_units: ExUnits;
+  script_context_bytes?: string | null;
   success: boolean;
   tag: RedeemerTag;
 }


### PR DESCRIPTION
## Summary

Adds an optional `script_context_bytes` field to `EvalRedeemerResult`, populated with the hex-encoded CBOR of the PlutusData script context that's passed into each Plutus script during phase-2 evaluation. The bytes are produced by encoding the same `ScriptContext::to_plutus_data()` value that gets applied to the program — so what you see is exactly what the VM saw.

This unblocks UI/tooling that wants to display, diff, or share the context a redeemer was evaluated against (useful when debugging \"my off-chain code and the script disagree about the context\").

\`None\` on the error-fallback path (script lookup / context build failed before any context existed).

## Test plan
- [ ] Existing phase-2 tests still pass
- [ ] Validate a tx with a Plutus script — \`script_context_bytes\` is a hex string roughly matching the structure the VM would see
- [ ] Validate a tx where script lookup fails — \`script_context_bytes\` is None